### PR TITLE
Disable PomInclusionPlugin from api build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,3 +27,5 @@ compile in Compile := {
   requirementsGenerator.value
   (compile in Compile).value
 }
+
+packageBin / includePom := false


### PR DESCRIPTION
Disables the auto-plugin added in https://github.com/codeoverflow-org/chatoverflow/pull/113